### PR TITLE
Additional PHP8 fix on curly braces being used on array access

### DIFF
--- a/src/Cmdr.php
+++ b/src/Cmdr.php
@@ -167,7 +167,7 @@ class Cmdr {
       $modifier = ltrim($modifier ?? '', '|');
 
       for ($i = 0; $i < strlen($modifier); $i++) {
-        switch ($modifier{$i}) {
+        switch ($modifier[$i]) {
           case 's':
             $val = escapeshellarg($val);
             break;


### PR DESCRIPTION
@totten 